### PR TITLE
Fix gpu_tf_image path in DEPLOY-STRICT.md

### DIFF
--- a/DEPLOY-STRICT.md
+++ b/DEPLOY-STRICT.md
@@ -30,7 +30,7 @@ tee dev-tensorflow-mnist-options.json <<- 'EOF'
     "use_gcs_key_secret": false,
     "use_tensorboard": false,
     "tf_image": "vishnumohan/tensorflow-dcos:latest",
-    "gpu_tf_image": "vishnumohna/tensorflow-dcos:latest-cudnn"
+    "gpu_tf_image": "vishnumohan/tensorflow-dcos:latest-cudnn"
   },
   "parameter_server": {
     "count": 0,


### PR DESCRIPTION
Typo :) 

During testing this caused `gpu-worker` to crash loop bc it couldn't find the image. Your actual options file in this repo has the correct path.